### PR TITLE
AVX Fixes

### DIFF
--- a/BuildScripts/project_common_skse64.lua
+++ b/BuildScripts/project_common_skse64.lua
@@ -25,7 +25,7 @@ project "common_skse64"
 	filter "system:windows"
 		systemversion "latest"
 		debugdir( "../bin/".. outputDir.. "/%{prj.name}" )
-		vectorextensions( _SIMD_MODE )
+		vectorextensions "AVX"
 		characterset "MBCS"
 		intrinsics "On"
 		fpu "Hardware"

--- a/BuildScripts/project_polyhook.lua
+++ b/BuildScripts/project_polyhook.lua
@@ -43,7 +43,7 @@ project "PolyHook2"
 	filter "system:windows"
 		systemversion "latest"
 		debugdir( "../bin/".. outputDir.. "/%{prj.name}" )
-		vectorextensions( _SIMD_MODE )
+		vectorextensions "AVX"
 		characterset "MBCS"
 		intrinsics "On"
 		fpu "Hardware"

--- a/BuildScripts/project_skse64.lua
+++ b/BuildScripts/project_skse64.lua
@@ -33,7 +33,7 @@ project "skse64"
 	filter "system:windows"
 		systemversion "latest"
 		debugdir( "../bin/".. outputDir.. "/%{prj.name}" )
-		vectorextensions( _SIMD_MODE )
+		vectorextensions "AVX"
 		characterset "MBCS"
 		intrinsics "On"
 		fpu "Hardware"

--- a/BuildScripts/project_skse64_common.lua
+++ b/BuildScripts/project_skse64_common.lua
@@ -33,7 +33,7 @@ project "skse64_common"
 	filter "system:windows"
 		systemversion "latest"
 		debugdir( "../bin/".. outputDir.. "/%{prj.name}" )
-		vectorextensions( _SIMD_MODE )
+		vectorextensions "AVX"
 		characterset "MBCS"
 		intrinsics "On"
 		fpu "Hardware"

--- a/SmoothCam/include/pch.h
+++ b/SmoothCam/include/pch.h
@@ -6,7 +6,7 @@
 #include <fstream>
 #include <filesystem>
 #include <thread>
-#include <xmmintrin.h>
+#include <immintrin.h>
 
 #include <new>
 void* operator new[](size_t size, const char* pName, int flags, unsigned debugFlags, const char* file, int line);

--- a/SmoothCam/source/mmath.cpp
+++ b/SmoothCam/source/mmath.cpp
@@ -98,32 +98,32 @@ NiMatrix33 mmath::ToddHowardTransform(const float pitch, const float yaw) noexce
 void mmath::DecomposeToBasis(const glm::vec3& point, const glm::vec3& rotation,
 	glm::vec3& forward, glm::vec3& right, glm::vec3& up, glm::vec3& coef) noexcept
 {
-	__m128 cosValues, sineValues;
+	__m256 cosValues, sineValues;
 	if constexpr (alignof(decltype(rotation)) == 16) {
-		__m128 rot = _mm_load_ps(rotation.data.data);
-		sineValues = _mm_sincos_ps(&cosValues, rot);
+		__m256 rot = _mm256_load_ps(rotation.data.data);
+		sineValues = _mm256_sincos_ps(&cosValues, rot);
 	} else {
-		__m128 rot = _mm_loadu_ps(rotation.data.data);
-		sineValues = _mm_sincos_ps(&cosValues, rot);
+		__m256 rot = _mm256_loadu_ps(rotation.data.data);
+		sineValues = _mm256_sincos_ps(&cosValues, rot);
 	}
-
-	const auto cZsX = cosValues.m128_f32[2] * sineValues.m128_f32[0];
-	const auto sXsZ = sineValues.m128_f32[0] * sineValues.m128_f32[2];
+	
+	const auto cZsX = cosValues.m256_f32[2] * sineValues.m256_f32[0];
+	const auto sXsZ = sineValues.m256_f32[0] * sineValues.m256_f32[2];
 	
 	forward = {
-		cosValues.m128_f32[1] * cosValues.m128_f32[2],
-		-cosValues.m128_f32[1] * sineValues.m128_f32[2],
-		sineValues.m128_f32[1]
+		cosValues.m256_f32[1] * cosValues.m256_f32[2],
+		-cosValues.m256_f32[1] * sineValues.m256_f32[2],
+		sineValues.m256_f32[1]
 	};
 	right = {
-		cZsX * sineValues.m128_f32[1] + cosValues.m128_f32[0] * sineValues.m128_f32[2],
-		cosValues.m128_f32[0] * cosValues.m128_f32[2] - sXsZ * sineValues.m128_f32[1],
-		-cosValues.m128_f32[1] * sineValues.m128_f32[0]
+		cZsX * sineValues.m256_f32[1] + cosValues.m256_f32[0] * sineValues.m256_f32[2],
+		cosValues.m256_f32[0] * cosValues.m256_f32[2] - sXsZ * sineValues.m256_f32[1],
+		-cosValues.m256_f32[1] * sineValues.m256_f32[0]
 	};
 	up = {
-		-cosValues.m128_f32[0] * cosValues.m128_f32[2] * sineValues.m128_f32[1] + sXsZ,
-		cZsX + cosValues.m128_f32[0] * sineValues.m128_f32[1] * sineValues.m128_f32[2],
-		cosValues.m128_f32[0] * cosValues.m128_f32[1]
+		-cosValues.m256_f32[0] * cosValues.m256_f32[2] * sineValues.m256_f32[1] + sXsZ,
+		cZsX + cosValues.m256_f32[0] * sineValues.m256_f32[1] * sineValues.m256_f32[2],
+		cosValues.m256_f32[0] * cosValues.m256_f32[1]
 	};
 
 	coef = {

--- a/SmoothCam/source/thirdperson.cpp
+++ b/SmoothCam/source/thirdperson.cpp
@@ -678,10 +678,12 @@ void Camera::Thirdperson::UpdateInternalRotation(const CorrectedPlayerCamera* ca
 	if (camera->cameraState == camera->cameraStates[CorrectedPlayerCamera::kCameraState_Transition]) {
 		auto cstate = reinterpret_cast<CorrectedPlayerCameraTransitionState*>(camera->cameraState);
 		tps = reinterpret_cast<CorrectedThirdPersonState*>(cstate->toState);
-	} else {
+	} else if (camera->cameraState == camera->cameraStates[CorrectedPlayerCamera::kCameraState_ThirdPerson2]) {
 		tps = reinterpret_cast<CorrectedThirdPersonState*>(camera->cameraState);
+	} else {
+		return;
 	}
-	
+
 	if (!tps) return;
 
 	// Alright, just lie and force the game to compute yaw for us

--- a/SmoothCam/source/thirdperson.cpp
+++ b/SmoothCam/source/thirdperson.cpp
@@ -671,13 +671,22 @@ void Camera::Thirdperson::MoveToGoalPosition(const PlayerCharacter* player, cons
 }
 
 void Camera::Thirdperson::UpdateInternalRotation(const CorrectedPlayerCamera* camera) noexcept {
-	const auto tps = reinterpret_cast<CorrectedThirdPersonState*>(camera->cameraState);
+	CorrectedThirdPersonState* tps;
+
+	// this is true when dismounting a horse, the camera is transitioning between the horseback and 3rd person camera
+	// see OnPreGameUpdate for setting the transition states
+	if (camera->cameraState == camera->cameraStates[CorrectedPlayerCamera::kCameraState_Transition]) {
+		auto cstate = reinterpret_cast<CorrectedPlayerCameraTransitionState*>(camera->cameraState);
+		tps = reinterpret_cast<CorrectedThirdPersonState*>(cstate->toState);
+	} else {
+		tps = reinterpret_cast<CorrectedThirdPersonState*>(camera->cameraState);
+	}
+	
 	if (!tps) return;
 
 	// Alright, just lie and force the game to compute yaw for us
 	// We get some jitter when things like magic change our character, not sure why yet @TODO
 	auto last = tps->freeRotationEnabled;
-	auto pl = *g_thePlayer;
 	tps->freeRotationEnabled = true;
 	tps->UpdateRotation();
 		rotation.SetQuaternion(tps->rotation);

--- a/make_vs2017.bat
+++ b/make_vs2017.bat
@@ -1,4 +1,4 @@
 @echo off
-premake5 --VS_PLATFORM=vs2017 --INTRIN=ON dd
-premake5 --VS_PLATFORM=vs2017 --INTRIN=ON dmake
-premake5 --VS_PLATFORM=vs2017 --INTRIN=ON vs2017
+premake5 --VS_PLATFORM=vs2017 dd
+premake5 --VS_PLATFORM=vs2017 dmake
+premake5 --VS_PLATFORM=vs2017 vs2017

--- a/make_vs2017_oldcpu.bat
+++ b/make_vs2017_oldcpu.bat
@@ -1,4 +1,0 @@
-@echo off
-premake5 --VS_PLATFORM=vs2017 --INTRIN=OFF dd
-premake5 --VS_PLATFORM=vs2017 --INTRIN=OFF dmake
-premake5 --VS_PLATFORM=vs2017 --INTRIN=OFF vs2017

--- a/make_vs2019.bat
+++ b/make_vs2019.bat
@@ -1,4 +1,4 @@
 @echo off
-premake5 --VS_PLATFORM=vs2019 --INTRIN=ON dd
-premake5 --VS_PLATFORM=vs2019 --INTRIN=ON dmake
-premake5 --VS_PLATFORM=vs2019 --INTRIN=ON vs2019
+premake5 --VS_PLATFORM=vs2019 dd
+premake5 --VS_PLATFORM=vs2019 dmake
+premake5 --VS_PLATFORM=vs2019 vs2019

--- a/make_vs2019_oldcpu.bat
+++ b/make_vs2019_oldcpu.bat
@@ -1,4 +1,0 @@
-@echo off
-premake5 --VS_PLATFORM=vs2019 --INTRIN=OFF dd
-premake5 --VS_PLATFORM=vs2019 --INTRIN=OFF dmake
-premake5 --VS_PLATFORM=vs2019 --INTRIN=OFF vs2019

--- a/premake5.lua
+++ b/premake5.lua
@@ -8,26 +8,8 @@ newoption {
 	}
 }
 
-newoption {
-	trigger = "INTRIN",
-	value = "ON",
-	description = "Enable use of hardware SIMD intrinsics.",
-	allowed = {
-		{ "ON", "Use SIMD instructions" },
-		{ "OFF", "Disable SIMD instructions" },
-	}
-}
-
 if not _OPTIONS["VS_PLATFORM"] then
 	return error( "No visual studio platform selected, please set --VS_PLATFORM to vs2017 or vs2019" )
-end
-
-if _OPTIONS["INTRIN"] == "ON" then
-	_SIMD_MODE = "AVX"
-	print "Using AVX instructions"
-else
-	_SIMD_MODE = "SSE"
-	print "Building for old CPUs"
 end
 
 local function rewriteFile(strPath, strData)
@@ -200,7 +182,7 @@ project "SmoothCam"
 	filter "system:windows"
 		systemversion "latest"
 		debugdir( "../bin/".. outputDir.. "/%{prj.name}" )
-		vectorextensions( _SIMD_MODE )
+		vectorextensions "AVX"
 		characterset "Unicode"
 		intrinsics "On"
 		fpu "Hardware"


### PR DESCRIPTION
This PR addresses the AVX issues:

The first change was made to the imports:
https://github.com/mwilsnd/SkyrimSE-SmoothCam/blob/c6f4ffcc6e8d9258103255c6b77d32669b244c49/SmoothCam/include/pch.h#L9
There are multiple different headers available for working with SSE and AVX, a list can be found [here](https://www.g-truc.net/post-0359.html) and is discussed in [this stackoverflow post](https://stackoverflow.com/questions/11228855/header-files-for-x86-simd-intrinsics):
```
+----------------+------------------------------------------------------------------------------------------+
|     Header     |                                         Purpose                                          |
+----------------+------------------------------------------------------------------------------------------+
| x86intrin.h    | Everything, including non-vector x86 instructions like _rdtsc().                         |
| mmintrin.h     | MMX (Pentium MMX!)                                                                       |
| mm3dnow.h      | 3dnow! (K6-2) (deprecated)                                                               |
| xmmintrin.h    | SSE + MMX (Pentium 3, Athlon XP)                                                         |
| emmintrin.h    | SSE2 + SSE + MMX (Pentium 4, Athlon 64)                                                  |
| pmmintrin.h    | SSE3 + SSE2 + SSE + MMX (Pentium 4 Prescott, Athlon 64 San Diego)                        |
| tmmintrin.h    | SSSE3 + SSE3 + SSE2 + SSE + MMX (Core 2, Bulldozer)                                      |
| popcntintrin.h | POPCNT (Nehalem (Core i7), Phenom)                                                       |
| ammintrin.h    | SSE4A + SSE3 + SSE2 + SSE + MMX (AMD-only, starting with Phenom)                         |
| smmintrin.h    | SSE4_1 + SSSE3 + SSE3 + SSE2 + SSE + MMX (Penryn, Bulldozer)                             |
| nmmintrin.h    | SSE4_2 + SSE4_1 + SSSE3 + SSE3 + SSE2 + SSE + MMX (Nehalem (aka Core i7), Bulldozer)     |
| wmmintrin.h    | AES (Core i7 Westmere, Bulldozer)                                                        |
| immintrin.h    | AVX, AVX2, AVX512, all SSE+MMX (except SSE4A and XOP), popcnt, BMI/BMI2, FMA             |
+----------------+------------------------------------------------------------------------------------------+
```

This PR changes the `xmmintrin.h` include to `immintrin.h` and uses the AVX `__m256` functions instead of the SSE ones. I also updated the build scripts to use `vectorextensions "AVX"` and removed the `_SIMD_MODE ` option.

AVX is supported by almost every CPU that has been released in the past 10 years (almost as old as Skyrim LE) so anyone playing modded Skyrim SE should have a compatible CPU which is why this PR goes fully AVX.

Here is a debug build with all the changes: [SmoothCam.zip](https://github.com/mwilsnd/SkyrimSE-SmoothCam/files/7433879/SmoothCam.zip)
