### PR TITLE
Fix misaligned arrow trajectory

### DIFF
--- a/SmoothCam/source/crosshair.cpp
+++ b/SmoothCam/source/crosshair.cpp
@@ -254,7 +254,7 @@ RE::NiAVObject* Crosshair::Manager::FindArrowNode(const RE::Actor* player) const
 	auto handNode = skyrim_cast<RE::NiNode*>(player->loadedData->data3D->GetObjectByName(Strings.weapon));
 	if (handNode && handNode->children.size() > 0) {
 		auto arrow = handNode->GetObjectByName(Strings.arrowName);
-		if (arrow) return arrow;
+		if (arrow) return handNode;
 	}
 
 	handNode = skyrim_cast<RE::NiNode*>(player->loadedData->data3D->GetObjectByName(Strings.rmag));


### PR DESCRIPTION
Fix misaligned arrow trajectory (use `WEAPON` node directly to get point from which arrow is launched, not `Arrow:0`).

Some arrows in-game have "broken" nifs where arrow tip isn't located at the origin of the coordinate space of the nif model itself. When these arrows are shot, SmoothCam tries to get the origin of that nif as the starting point for the arc, which leads to pretty sizeable misses.

`WEAPON` node, however, seems to fit perfectly. Further exhaustive testing is needed, of course, with vanilla and modded bows alike. Possibly with modded skeletons as well. But I strongly suspect that `WEAPON` node is what game uses to launch arrows from.